### PR TITLE
Add retry policy for connection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "require": {
         "php": "^7.1",
         "keboola/php-component": "^5.0",
+        "keboola/retry": "^0.4.1",
         "keboola/sanitizer": "^0.1.0",
         "league/flysystem": "^1.0",
         "league/flysystem-sftp": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "781931af961c04c7e7cab77537bd3f6a",
+    "content-hash": "72adcbab994172dda647bf22dc6efc8e",
     "packages": [
         {
             "name": "keboola/php-component",
@@ -60,6 +60,57 @@
                 "keboola"
             ],
             "time": "2018-10-23T14:20:29+00:00"
+        },
+        {
+            "name": "keboola/retry",
+            "version": "0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/keboola/retry.git",
+                "reference": "6a090d625f01b06ba91242832cdb575f7a5a28af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/keboola/retry/zipball/6a090d625f01b06ba91242832cdb575f7a5a28af",
+                "reference": "6a090d625f01b06ba91242832cdb575f7a5a28af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/log": "^1.1"
+            },
+            "replace": {
+                "vkartaviy/retry": "*"
+            },
+            "require-dev": {
+                "keboola/coding-standard": "^7.0",
+                "phpstan/phpstan-shim": "^0.10",
+                "phpunit/phpunit": "7.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Retry\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Keboola Dev",
+                    "email": "devel@keboola.com"
+                }
+            ],
+            "description": "Library for repeatable and retryable operations",
+            "keywords": [
+                "backoff",
+                "proxy",
+                "repeat",
+                "retry"
+            ],
+            "time": "2019-08-19T13:47:21+00:00"
         },
         {
             "name": "keboola/sanitizer",


### PR DESCRIPTION
Fix #22 

Původně jsem chtěl udělat vlastní obálku nad každým adaptérem abych přetížil `AbstractFtpAdapter::getConnection()` viz `https://github.com/thephpleague/flysystem/blob/36f1ab08462e8239b616fd3828ace2a78d3a7cbe/src/Adapter/AbstractFtpAdapter.php#L636` ale je to overhead.