### PR TITLE
Better exceptions handling, COM-106

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -155,16 +155,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.56",
+            "version": "1.0.64",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "90e3f83cb10ef6b058d70f95267030e7a6236518"
+                "reference": "d13c43dbd4b791f815215959105a008515d1a2e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/90e3f83cb10ef6b058d70f95267030e7a6236518",
-                "reference": "90e3f83cb10ef6b058d70f95267030e7a6236518",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/d13c43dbd4b791f815215959105a008515d1a2e0",
+                "reference": "d13c43dbd4b791f815215959105a008515d1a2e0",
                 "shasum": ""
             },
             "require": {
@@ -176,7 +176,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^3.4",
-                "phpunit/phpunit": "^5.7.10"
+                "phpunit/phpunit": "^5.7.26"
             },
             "suggest": {
                 "ext-fileinfo": "Required for MimeType",
@@ -235,7 +235,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2019-10-12T13:05:59+00:00"
+            "time": "2020-02-05T18:14:17+00:00"
         },
         {
             "name": "league/flysystem-sftp",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.2'
 services:
   app:
     build: .

--- a/src/Exception/ExceptionConverter.php
+++ b/src/Exception/ExceptionConverter.php
@@ -54,7 +54,7 @@ final class ExceptionConverter
 
         // Catch user_error from phpseclib
         // phpcs:disable
-        if (preg_match_all('/(getaddrinfo failed)|(Could not connect to)|(Cannot connect to)|(Root is invalid)|(The authenticity of)|(Connection closed prematurely)/', $e->getMessage())) {
+        if (preg_match_all('/(getaddrinfo failed)|(Cannot connect to)|(The authenticity of)|(Connection closed prematurely)/', $e->getMessage())) {
             self::toUserException($e);
         }
         // phpcs:enable

--- a/src/Exception/ExceptionConverter.php
+++ b/src/Exception/ExceptionConverter.php
@@ -6,6 +6,7 @@ namespace Keboola\FtpExtractor\Exception;
 
 use Keboola\Component\UserException;
 use League\Flysystem\FileNotFoundException;
+use League\Flysystem\FilesystemException;
 use League\Flysystem\Sftp\SftpAdapterException;
 
 final class ExceptionConverter
@@ -16,12 +17,13 @@ final class ExceptionConverter
             self::toUserException($e);
         }
 
-        if ($e instanceof FileNotFoundException) {
+        if ($e instanceof FilesystemException) {
             self::toUserException($e);
         }
 
+        // Catch user_error from phpseclib
         // phpcs:disable
-        if (preg_match_all('/(Could not login)|(getaddrinfo failed)|(Could not connect to)|(Cannot connect to)|(Root is invalid)|(The authenticity of)|(Connection closed prematurely)/', $e->getMessage())) {
+        if (preg_match_all('/(getaddrinfo failed)|(Could not connect to)|(Cannot connect to)|(Root is invalid)|(The authenticity of)|(Connection closed prematurely)/', $e->getMessage())) {
             self::toUserException($e);
         }
         // phpcs:enable

--- a/tests/phpunit/ExceptionConverterTest.php
+++ b/tests/phpunit/ExceptionConverterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\FtpExtractor\Tests;
 
 use Keboola\FtpExtractor\Exception\ApplicationException;
+use League\Flysystem\ConnectionRuntimeException;
 use League\Flysystem\Sftp\ConnectionErrorException;
 use League\Flysystem\Sftp\InvalidRootException;
 use PHPUnit\Framework\TestCase;
@@ -101,7 +102,7 @@ class ExceptionConverterTest extends TestCase
             [
                 UserException::class,
                 'Could not connect to server to verify public key.',
-                new \RuntimeException('Could not connect to server to verify public key.'),
+                new ConnectionRuntimeException('Could not connect to server to verify public key.'),
             ],
             [
                 UserException::class,
@@ -116,7 +117,7 @@ class ExceptionConverterTest extends TestCase
             [
                 UserException::class,
                 'Root is invalid or does not exist: /foo/bar',
-                new \RuntimeException('Root is invalid or does not exist: /foo/bar'),
+                new InvalidRootException('Root is invalid or does not exist: /foo/bar'),
             ],
             [
                 UserException::class,

--- a/tests/phpunit/ExceptionConverterTest.php
+++ b/tests/phpunit/ExceptionConverterTest.php
@@ -128,6 +128,14 @@ class ExceptionConverterTest extends TestCase
                 'Foo bar',
                 new \RuntimeException('Foo bar'),
             ],
+            [
+                UserException::class,
+                sprintf(
+                    'Connection was terminated. Check that the connection is not blocked by Firewall: ' .
+                    'Operation now in progress (115)'
+                ),
+                new \ErrorException('Operation now in progress (115)'),
+            ],
         ];
     }
 

--- a/tests/phpunit/ExceptionConverterTest.php
+++ b/tests/phpunit/ExceptionConverterTest.php
@@ -89,7 +89,7 @@ class ExceptionConverterTest extends TestCase
             [
                 UserException::class,
                 'Could not login with username: foo bar',
-                new \RuntimeException('Could not login with username: foo bar'),
+                new ConnectionErrorException('Could not login with username: foo bar'),
             ],
             [
                 UserException::class,


### PR DESCRIPTION
Changes:
- Updated version of `league/flysystem` 1.0.56 => 1.0.64
- Updated version in `docker-compose.yml` version 2.0 -> 2.2
  - phpstorm can run phpunit in docker environment without problems
- Modified code to use new `League\Flysystem\FilesystemException`
- Added clear msg for `ftp_rawlist()...` problem, #11 
- All covered by tests